### PR TITLE
implemented fetching killmail details from ESI

### DIFF
--- a/src/src/interfaces/zkill.ts
+++ b/src/src/interfaces/zkill.ts
@@ -5,18 +5,10 @@ import { IAlliances } from '../models/alliances';
 import { IShips } from '../models/ships';
 import { IFaction } from '../models/faction';
 
-export interface IZkillPoll {
+interface IZkillPoll {
     killID: number;
-    killmail: IKzillPollKillmail;
     zkb: IZkillPollZkb;
-}
-
-interface IKzillPollKillmail {
-    attackers: IZkillAttacker[];
-    killmail_id: number;
-    killmail_time: string;
-    solar_system_id: number;
-    victim: IZkillVictim;
+    href: string;
 }
 
 interface IZkillPollZkb {
@@ -47,7 +39,7 @@ interface IZkill {
     extendedFinalBlow?: IZkillExtended
 }
 
-export interface IZkillExtended {
+interface IZkillExtended {
     systemData: ISolarSystem;
     character?: ICharacters
     corporation?: ICorps
@@ -57,9 +49,9 @@ export interface IZkillExtended {
 }
 
 interface IZkillAttacker {
-    alliance_id: number;
-    character_id: number;
-    corporation_id: number;
+    alliance_id?: number;
+    character_id?: number;
+    corporation_id?: number;
     damage_done: number;
     faction_id: number;
     final_blow: boolean;
@@ -70,13 +62,13 @@ interface IZkillAttacker {
 }
 
 interface IZkillVictim {
-    alliance_id: number;
-    character_id: number;
-    corporation_id: number;
+    alliance_id?: number;
+    character_id?: number;
+    corporation_id?: number;
     damage_taken: number;
-    faction_id: number;
-    items: any[];
-    position: IZkillPosition;
+    faction_id?: number;
+    items?: any[];
+    position?: IZkillPosition;
     ship_type_id: number;
 }
 
@@ -103,4 +95,12 @@ interface IZkillZkb {
     href?: string;
 }
 
-export { IZkill, IZkillAttacker, IZkillVictim, IZkillPosition, IZkillZkb };
+interface IESIKillmail {
+    killmail_id: number;
+    killmail_time: string;
+    solar_system_id: number;
+    attackers: IZkillAttacker[];
+    victim: IZkillVictim;
+}
+
+export { IZkill, IZkillAttacker, IZkillVictim, IZkillPosition, IZkillZkb, IESIKillmail, IZkillExtended, IZkillPoll };

--- a/src/src/lib/killResolver.ts
+++ b/src/src/lib/killResolver.ts
@@ -1,0 +1,28 @@
+import { EsiClient } from './esiClient';
+import { IESIKillmail, IZkillPoll } from '../interfaces/zkill';
+
+const ENABLE_KILLS_RESOLVER_LOG = false; // Set to true to enable logging
+
+function log(...args: any[]) {
+    if (ENABLE_KILLS_RESOLVER_LOG) {
+        console.log('[KillResolver]', ...args);
+    }
+}
+
+export class KillResolver {
+    protected static instance: KillResolver;
+
+    public static getInstance(): KillResolver {
+        if (!KillResolver.instance) {
+            KillResolver.instance = new KillResolver();
+        }
+        return KillResolver.instance;
+    }
+
+    public async resolveKill(kill: IZkillPoll): Promise<IESIKillmail | undefined> {
+        log('Resolving kill:', kill);
+        const esiClient = EsiClient.getInstance();
+        log('Fetching killmail from ESI for href:', kill.zkb.href);
+        return await esiClient.getKillmailFromESIByUrl(kill.zkb.href || `https://esi.evetech.net/killmails/${kill.killID}/${kill.zkb.hash}/`);
+    }
+}

--- a/src/src/lib/killTransformer.ts
+++ b/src/src/lib/killTransformer.ts
@@ -1,12 +1,17 @@
+import { KillResolver } from './killResolver';
 import { IZkillPoll, IZkill } from '../interfaces/zkill';
 
-export function transformKill(kill: IZkillPoll) : IZkill {
+export async function transformKill(kill: IZkillPoll) : Promise<IZkill> {
+    const esiKillmail = await KillResolver.getInstance().resolveKill(kill);
+    if (!esiKillmail) {
+        throw new Error('Failed to resolve killmail from ESI');
+    }
     return {
-        attackers: kill.killmail.attackers,
-        killmail_id: kill.killmail.killmail_id,
-        killmail_time: kill.killmail.killmail_time,
-        solar_system_id: kill.killmail.solar_system_id,
-        victim: kill.killmail.victim,
+        attackers: esiKillmail.attackers,
+        killmail_id: esiKillmail.killmail_id,
+        killmail_time: esiKillmail.killmail_time,
+        solar_system_id: esiKillmail.solar_system_id,
+        victim: esiKillmail.victim,
         zkb: {
             locationID: kill.zkb.locationID,
             hash: kill.zkb.hash,
@@ -20,7 +25,7 @@ export function transformKill(kill: IZkillPoll) : IZkill {
             awox: kill.zkb.awox,
             esi: kill.zkb.esi,
             //  https://zkillboard.com/kill/<killmail_id>/
-            url: kill.zkb.url || `https://zkillboard.com/kill/${kill.killmail.killmail_id}/`,
+            url: kill.zkb.url || `https://zkillboard.com/kill/${kill.killID}/`,
             labels: kill.zkb.labels,
             href: kill.zkb.href,
         },

--- a/src/src/zKillSubscriber.ts
+++ b/src/src/zKillSubscriber.ts
@@ -87,7 +87,7 @@ export class ZKillSubscriber {
             if (response.data.package) {
                 const rawData: IZkillPoll = response.data.package;
                 // Transform the data to match the expected format
-                const data = transformKill(rawData);
+                const data = await transformKill(rawData);
                 // console.log(`Added killmail ${data.killmail_id} to the queue.`); // keep for debugging
                 await this.queue.add(
                     'process-kill',


### PR DESCRIPTION
- removed `killmail ` field from `IZkillPoll`
- implemented fetching killmail from ESI using zkb.href with fallback to manually forming ESI killmail link using kill ID and hash
- killTransformer.transformKill now will fetch killmail from ESI (using KillResolver) and use it's data instead of `killmail` field data
- checked it working on my own bot